### PR TITLE
Base screens, top bar, bottom nav bar, splash screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId = "com.example.cs446_fit4me"
-        minSdk = 25
+        minSdk = 26
         targetSdk = 35
         versionCode = 1
         versionName = "1.0"
@@ -49,6 +49,9 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    implementation(libs.androidx.glance)
+    implementation(libs.androidx.glance.appwidget)
+    implementation(libs.androidx.glance.wear.tiles)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
@@ -56,4 +59,6 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
+    implementation(libs.androidx.core.splashscreen)
+    implementation(libs.androidx.navigation.compose)
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.CS446fit4me">
+            android:theme="@style/Theme.App.Starting">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/example/cs446_fit4me/MainActivity.kt
+++ b/app/src/main/java/com/example/cs446_fit4me/MainActivity.kt
@@ -4,44 +4,19 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.example.cs446_fit4me.ui.theme.CS446fit4meTheme
+import com.example.cs446_fit4me.ui.screens.MainScreen
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
+        installSplashScreen()
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
             CS446fit4meTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
-                }
+                  MainScreen()
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    CS446fit4meTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/com/example/cs446_fit4me/navigation/BottomNavItem.kt
+++ b/app/src/main/java/com/example/cs446_fit4me/navigation/BottomNavItem.kt
@@ -1,0 +1,27 @@
+package com.example.cs446_fit4me.navigation
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Face // replace with actual icons
+import androidx.compose.ui.graphics.vector.ImageVector
+
+// Sealed class to represent bottom navigation screens
+sealed class BottomNavItem(
+    val route: String,
+    val title: String,
+    val icon: ImageVector,
+    val label: String
+) {
+    object Home : BottomNavItem("home", "Home", Icons.Filled.Home, "Home")
+    object Messages : BottomNavItem("messages", "Messages", Icons.Filled.Email, "Messages")
+    object FindMatch : BottomNavItem("find_match", "Find A Gym Buddy", Icons.Filled.Face, "Find Match")
+    object Workout : BottomNavItem("workout", "Get those Gainz!!!!", Icons.Filled.Add, "Workout")
+    object Profile : BottomNavItem("profile", "Profile", Icons.Filled.AccountCircle, "Profile")
+}
+
+fun getTitleByRoute(route: String?, items: List<BottomNavItem>): String {
+    return items.find { it.route == route }?.title ?: "Fit4Me" // Default title
+}

--- a/app/src/main/java/com/example/cs446_fit4me/ui/components/BottomNavigationBar.kt
+++ b/app/src/main/java/com/example/cs446_fit4me/ui/components/BottomNavigationBar.kt
@@ -1,0 +1,49 @@
+package com.example.cs446_fit4me.ui.components
+
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavController
+import androidx.navigation.compose.currentBackStackEntryAsState
+import com.example.cs446_fit4me.navigation.BottomNavItem
+
+@Composable
+fun BottomNavigationBar(navController: NavController, items: List<BottomNavItem>) {
+    NavigationBar {
+        val navBackStackEntry by navController.currentBackStackEntryAsState()
+        val currentRoute = navBackStackEntry?.destination?.route
+
+        items.forEach { item ->
+            NavigationBarItem(
+                icon = { Icon(item.icon, contentDescription = item.label) },
+                label = { Text(item.label) },
+                selected = currentRoute == item.route,
+                onClick = {
+                    navController.navigate(item.route) {
+                        // When switching to a new tab, pop the navigation stack to HomeScreen
+                        // i.e. clicking <back> after switching to new tab goes to HomeScreen
+                        // and no <back> button appears on HomeScreen
+                        popUpTo(navController.graph.startDestinationId) {
+                            saveState = true
+                        }
+                        // Avoid multiple copies of the same destination
+                        launchSingleTop = true
+                        // Restore state when reselecting a previously selected item
+                        restoreState = true
+                    }
+                }
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewBottomNavigationBar() {
+    // This preview won't have real navigation state, but shows the layout
+//     BottomNavigationBar(navController = rememberNavController() /*Dummy for preview*/, items = ...)
+}

--- a/app/src/main/java/com/example/cs446_fit4me/ui/components/TopBar.kt
+++ b/app/src/main/java/com/example/cs446_fit4me/ui/components/TopBar.kt
@@ -1,0 +1,58 @@
+package com.example.cs446_fit4me.ui.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TopBar(
+    title: String,
+    canNavigateBack: Boolean,
+    onNavigateUp: () -> Unit = {} // Callback for back button
+) {
+    TopAppBar(
+        title = { Text(title) },
+        // change to use our theme colours
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = Color.LightGray,
+            titleContentColor = Color.Black,
+        ),
+        navigationIcon = {
+            if (canNavigateBack) {
+                IconButton(onClick = onNavigateUp) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back"
+                    )
+                }
+            }
+        }
+        // You can add actions here if needed
+        // actions = {
+        //     IconButton(onClick = { /* do something */ }) {
+        //         Icon(Icons.Filled.Favorite, contentDescription = "Favorite")
+        //     }
+        // }
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewAppTopBarWithBack() {
+    TopBar(title = "Screen Title", canNavigateBack = true)
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PreviewAppTopBarWithoutBack() {
+    TopBar(title = "Screen Title", canNavigateBack = false)
+}

--- a/app/src/main/java/com/example/cs446_fit4me/ui/screens/FindMatchScreen.kt
+++ b/app/src/main/java/com/example/cs446_fit4me/ui/screens/FindMatchScreen.kt
@@ -1,0 +1,29 @@
+package com.example.cs446_fit4me.ui.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavController
+import com.example.cs446_fit4me.ui.theme.CS446fit4meTheme
+
+@Composable
+fun FindMatchScreen(navController: NavController? = null) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text("Welcome to the Find A Gym Buddy Screen!")
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun FindMatchScreenPreview() {
+    CS446fit4meTheme {
+        FindMatchScreen()
+    }
+}

--- a/app/src/main/java/com/example/cs446_fit4me/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/example/cs446_fit4me/ui/screens/HomeScreen.kt
@@ -1,0 +1,29 @@
+package com.example.cs446_fit4me.ui.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavController
+import com.example.cs446_fit4me.ui.theme.CS446fit4meTheme
+
+@Composable
+fun HomeScreen(navController: NavController? = null) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text("Welcome to the Home Screen!")
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun HomeScreenPreview() {
+    CS446fit4meTheme {
+        HomeScreen()
+    }
+}

--- a/app/src/main/java/com/example/cs446_fit4me/ui/screens/MainScreen.kt
+++ b/app/src/main/java/com/example/cs446_fit4me/ui/screens/MainScreen.kt
@@ -1,0 +1,65 @@
+package com.example.cs446_fit4me.ui.screens
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import com.example.cs446_fit4me.navigation.BottomNavItem
+import com.example.cs446_fit4me.navigation.getTitleByRoute
+import com.example.cs446_fit4me.ui.components.BottomNavigationBar
+import com.example.cs446_fit4me.ui.components.TopBar
+
+// Main screen that contains the bottom navigation bar and the navigation host
+@Composable
+fun MainScreen() {
+    val navController = rememberNavController()
+    val bottomNavItems = listOf(
+        BottomNavItem.Messages,
+        BottomNavItem.FindMatch,
+        BottomNavItem.Home,
+        BottomNavItem.Workout,
+        BottomNavItem.Profile
+    )
+
+    // Get current route to determine title and back navigation state
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = navBackStackEntry?.destination?.route
+    val currentScreenTitle = getTitleByRoute(currentRoute, bottomNavItems)
+
+    // Determine if back navigation is possible
+    val canNavigateBack = navController.previousBackStackEntry != null
+
+    Scaffold(
+        topBar = {
+            // Only show TopAppBar if the current route is one of the bottom nav items
+            // May need to adjust this logic when we have more fragments
+            if (bottomNavItems.any { it.route == currentRoute }) {
+                TopBar(
+                    title = currentScreenTitle,
+                    canNavigateBack = canNavigateBack,
+                    onNavigateUp = { navController.navigateUp() }
+                )
+            }
+        },
+        bottomBar = {
+            BottomNavigationBar(navController = navController, items = bottomNavItems)
+        }
+    ) { innerPadding ->
+        NavHost(
+            navController = navController,
+            startDestination = BottomNavItem.Home.route,
+            modifier = Modifier.padding(innerPadding)
+        ) {
+            composable(BottomNavItem.Home.route) { HomeScreen(navController) }
+            composable(BottomNavItem.Messages.route) { MessagesScreen(navController) }
+            composable(BottomNavItem.FindMatch.route) { FindMatchScreen(navController) }
+            composable(BottomNavItem.Workout.route) { WorkoutScreen(navController) }
+            composable(BottomNavItem.Profile.route) { ProfileScreen(navController) }
+        }
+    }
+}

--- a/app/src/main/java/com/example/cs446_fit4me/ui/screens/MessagesScreen.kt
+++ b/app/src/main/java/com/example/cs446_fit4me/ui/screens/MessagesScreen.kt
@@ -1,0 +1,29 @@
+package com.example.cs446_fit4me.ui.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavController
+import com.example.cs446_fit4me.ui.theme.CS446fit4meTheme
+
+@Composable
+fun MessagesScreen(navController: NavController? = null) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text("Welcome to the Messages Screen!")
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun MessagesPreview() {
+    CS446fit4meTheme {
+        MessagesScreen()
+    }
+}

--- a/app/src/main/java/com/example/cs446_fit4me/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/example/cs446_fit4me/ui/screens/ProfileScreen.kt
@@ -1,0 +1,29 @@
+package com.example.cs446_fit4me.ui.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavController
+import com.example.cs446_fit4me.ui.theme.CS446fit4meTheme
+
+@Composable
+fun ProfileScreen(navController: NavController? = null) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text("Welcome to the Profile Screen!")
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ProfileScreenPreview() {
+    CS446fit4meTheme {
+        ProfileScreen()
+    }
+}

--- a/app/src/main/java/com/example/cs446_fit4me/ui/screens/WorkoutScreen.kt
+++ b/app/src/main/java/com/example/cs446_fit4me/ui/screens/WorkoutScreen.kt
@@ -1,0 +1,29 @@
+package com.example.cs446_fit4me.ui.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavController
+import com.example.cs446_fit4me.ui.theme.CS446fit4meTheme
+
+@Composable
+fun WorkoutScreen(navController: NavController? = null) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text("Welcome to the Workout Screen!")
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun WorkoutScreenPreview() {
+    CS446fit4meTheme {
+        WorkoutScreen()
+    }
+}

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -2,4 +2,33 @@
 <resources>
 
     <style name="Theme.CS446fit4me" parent="android:Theme.Material.Light.NoActionBar" />
+       <!-- Base application theme (your main app theme) -->
+    <style name="Theme.YourApp" parent="android:Theme.Material.Light.NoActionBar">
+        <!-- Customize your main app theme here if needed -->
+    </style>
+
+       <!-- I'm thinking for splash screen that it's the blueberry bobbing up and down -->
+
+       <!-- Splash Screen Theme -->
+    <style name="Theme.App.Starting" parent="Theme.SplashScreen">
+        <!-- Required: Set the theme of the Activity that follows your splash screen. -->
+        <!-- This should be your main app theme (the one your Compose UI will use). -->
+        <item name="postSplashScreenTheme">@style/Theme.YourApp</item>
+
+        <!-- Required: Set your icon or animated icon. -->
+        <!-- Use windowSplashScreenAnimatedIcon for static drawables or animated drawables. -->
+        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
+        <!-- Or for adaptive icons (Android 8.0+), you can use just the icon: -->
+        <!-- <item name="windowSplashScreenIconBackgroundColor">@android:color/white</item> -->
+        <!-- <item name="windowSplashScreenBrandingImage">@drawable/your_brand_logo</item> -->
+
+
+        <!-- Optional: Set a background color for the splash screen window. -->
+        <item name="windowSplashScreenBackground">@android:color/white</item>
+        <!-- <item name="windowSplashScreenBackground">@color/your_splash_background_color</item> -->
+
+
+        <!-- Optional: For an animated icon, set its duration. -->
+        <!-- <item name="windowSplashScreenAnimationDuration">1000</item> -->
+    </style>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,11 @@ espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.9.0"
 activityCompose = "1.10.1"
 composeBom = "2024.09.00"
+coreSplashscreen = "1.0.1"
+navigationCompose = "2.7.7"
+glance = "1.2.0-alpha01"
+glanceAppwidget = "1.2.0-alpha01"
+glanceWearTiles = "1.0.0-alpha05"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -24,6 +29,11 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "coreSplashscreen" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+androidx-glance = { group = "androidx.glance", name = "glance", version.ref = "glance" }
+androidx-glance-appwidget = { group = "androidx.glance", name = "glance-appwidget", version.ref = "glanceAppwidget" }
+androidx-glance-wear-tiles = { group = "androidx.glance", name = "glance-wear-tiles", version.ref = "glanceWearTiles" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Added:
* base screens for Home, Workout, Profile, Matching, Messages
* top bar containing name of screen and back button (if applicable)
* bottom nav bar containing placeholder icons 
* splash screen containing placeholder icon